### PR TITLE
fix config.py

### DIFF
--- a/src/nonebot_plugin_suggarchat/config.py
+++ b/src/nonebot_plugin_suggarchat/config.py
@@ -239,6 +239,7 @@ class ConfigManager:
             self.config.save_to_toml(self.toml_config)
 
         # private_train
+        prompt = ""
         if self.private_prompt.is_file():
             with self.private_prompt.open("r", encoding="utf-8") as f:
                 prompt = f.read()
@@ -250,6 +251,7 @@ class ConfigManager:
                 f.write(prompt)
 
         # group_train
+        prompt = ""
         if self.group_prompt.is_file():
             with self.group_prompt.open("r", encoding="utf-8") as f:
                 prompt = f.read()


### PR DESCRIPTION
fix #73 
通过在前面声明prompt，让首次运行时能正常生成配置文件