### PR TITLE
Refactor Adapter System, Enhance Session & Concurrency

### DIFF
--- a/nonebot_plugin_suggarchat/API.py
+++ b/nonebot_plugin_suggarchat/API.py
@@ -128,6 +128,7 @@ class Adapter:
         """
         return adapter_class
 
+
 class Menu:
     """
     Menu 类用于通过注册菜单项来构建菜单。

--- a/nonebot_plugin_suggarchat/API.py
+++ b/nonebot_plugin_suggarchat/API.py
@@ -1,5 +1,7 @@
+import warnings
 from collections.abc import Callable
 
+import typing_extensions
 from nonebot import logger
 
 from .chatmanager import chat_manager
@@ -7,16 +9,30 @@ from .config import Config as Conf
 from .config import ConfigManager, config_manager
 from .utils.admin import send_to_admin
 from .utils.libchat import (
+    ModelAdapter,
+    adapter_class,
     get_chat,
     protocols_adapters,
+    tools_caller,
 )
+from .utils.tokenizer import Tokenizer, hybrid_token_count
 
-Config: ConfigManager = config_manager
+__all__ = [
+    "ConfigManager",
+    "Tokenizer",
+    "config_manager",
+    "hybrid_token_count",
+    "tools_caller",
+]
 
 
 class Adapter:
     """用于处理Adapter注册的类"""
 
+    @typing_extensions.deprecated(
+        "请使用register_adapter_class方法",
+        category=None,
+    )
     def register_adapter(self, func: Callable, protocol: str):
         """注册一个适配器。
 
@@ -27,11 +43,32 @@ class Adapter:
         Raises:
             ValueError: 这个协议的适配器已经注册了。
         """
+        warnings.warn(
+            "请使用Adapter.register_adapter()注册适配器，请使用新的Adpater规范",
+            DeprecationWarning,
+        )
         if protocol in protocols_adapters and not config_manager.config_dir:
             raise ValueError("协议适配器已存在")
         else:
             protocols_adapters[protocol] = func
 
+    def register_adapter_class(self, adapter: type[ModelAdapter]) -> None:
+        """注册一个适配器类。
+
+        Args:
+            adapter (type[ModelAdapter]): 适配器类
+
+        Raises:
+            ValueError: 这个适配器类已经注册了。
+        """
+        if adapter.get_adapter_protocol() in adapter_class:
+            raise ValueError(
+                f"这个适配器类已经注册了：{adapter.get_adapter_protocol()}"
+            )
+
+    @typing_extensions.deprecated(
+        "请使用 get_adapter_class() 方法获取适配器。", category=None
+    )
     def get_adapter(self, protocol: str) -> Callable:
         """获取适配器方法。
 
@@ -44,27 +81,52 @@ class Adapter:
         Returns:
             Callable: 返回的函数
         """
+        warnings.warn(
+            "请使用 get_adapter_protocol() 方法获取协议适配器", DeprecationWarning
+        )
         if protocol not in protocols_adapters:
             raise ValueError("协议适配器不存在")
         return protocols_adapters[protocol]
 
+    def get_adapter_class(self, protocol: str) -> type[ModelAdapter]:
+        if protocol not in adapter_class:
+            raise ValueError("协议适配器不存在")
+        return adapter_class[protocol]
+
+    def get_adapter_classes(self) -> dict[str, type[ModelAdapter]]:
+        return adapter_class
+
+    @typing_extensions.deprecated(
+        "请使用 get_adapters_classes() 方法获取适配器。", category=None
+    )
     def get_adapters(self) -> dict[str, Callable]:
         """获取适配器方法
 
         Returns:
             dict[str,Callable]: 包含适配器与协议的字典
         """
+        warnings.warn("请使用get_adapters()方法", DeprecationWarning)
         return protocols_adapters
 
     @property
+    @typing_extensions.deprecated("请使用 adapter_classes 获取适配器。", category=None)
     def adapters(self) -> dict[str, Callable]:
         """获取适配器方法
 
         Returns:
             dict[str,Callable]: 包含适配器与协议的字典
         """
+        warnings.warn("请使用adapter_classes属性", DeprecationWarning)
         return protocols_adapters
 
+    @property
+    def adapter_classes(self) -> dict[str, type[ModelAdapter]]:
+        """获取适配器类方法
+
+        Returns:
+            dict[str,Type[ModelAdapter]]: 适配器类字典
+        """
+        return adapter_class
 
 class Menu:
     """

--- a/nonebot_plugin_suggarchat/API.py
+++ b/nonebot_plugin_suggarchat/API.py
@@ -5,8 +5,7 @@ import typing_extensions
 from nonebot import logger
 
 from .chatmanager import chat_manager
-from .config import Config as Conf
-from .config import ConfigManager, config_manager
+from .config import Config, ConfigManager, config_manager
 from .utils.admin import send_to_admin
 from .utils.libchat import (
     ModelAdapter,
@@ -160,7 +159,7 @@ class Admin:
     管理员管理类，负责处理与管理员相关的操作，如发送消息、错误处理和管理员权限管理。
     """
 
-    config: Conf
+    config: Config
 
     def __init__(self):
         """
@@ -244,7 +243,7 @@ class Chat:
     Chat 类用于处理与LLM相关操作，如获取消息。
     """
 
-    config: Conf
+    config: Config
 
     def __init__(self):
         """

--- a/nonebot_plugin_suggarchat/API.py
+++ b/nonebot_plugin_suggarchat/API.py
@@ -64,6 +64,7 @@ class Adapter:
             raise ValueError(
                 f"这个适配器类已经注册了：{adapter.get_adapter_protocol()}"
             )
+        adapter_class[adapter.get_adapter_protocol()] = adapter
 
     @typing_extensions.deprecated(
         "请使用 get_adapter_class() 方法获取适配器。", category=None

--- a/nonebot_plugin_suggarchat/chatmanager.py
+++ b/nonebot_plugin_suggarchat/chatmanager.py
@@ -1,12 +1,20 @@
 from dataclasses import dataclass, field
+from datetime import datetime
 from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class SessionTemp(BaseModel):
+    message_id: int
+    timestamp: datetime = Field(default_factory=datetime.now)
 
 
 @dataclass
 class ChatManager:
     debug: bool = False
-    session_clear_group: list[dict[str, Any]] = field(default_factory=list)
-    session_clear_user: list[dict[str, Any]] = field(default_factory=list)
+    session_clear_group: dict[str, SessionTemp] = field(default_factory=dict)
+    session_clear_user: dict[str, SessionTemp] = field(default_factory=dict)
     custom_menu: list[dict[str, str]] = field(default_factory=list)
     running_messages_poke: dict[str, Any] = field(default_factory=dict)
     menu_msg: str = "聊天功能菜单:\n" + "/聊天菜单 唤出菜单 \n"

--- a/nonebot_plugin_suggarchat/handlers/chat.py
+++ b/nonebot_plugin_suggarchat/handlers/chat.py
@@ -46,6 +46,7 @@ _Group_Lock = defaultdict(asyncio.Lock)
 _Private_Lock = defaultdict(asyncio.Lock)
 command_prefix = get_driver().config.command_start or "/"
 
+
 async def chat(event: MessageEvent, matcher: Matcher, bot: Bot):
     """
     聊天处理主函数，根据消息类型（群聊或私聊）调用对应的处理逻辑。

--- a/nonebot_plugin_suggarchat/handlers/chat.py
+++ b/nonebot_plugin_suggarchat/handlers/chat.py
@@ -5,10 +5,11 @@ import random
 import sys
 import time
 import traceback
+from collections import defaultdict
 from datetime import datetime
 from typing import Any
 
-from nonebot import logger
+from nonebot import get_driver, logger
 from nonebot.adapters.onebot.v11 import (
     Bot,
     MessageSegment,
@@ -22,14 +23,13 @@ from nonebot.adapters.onebot.v11.event import (
 from nonebot.exception import NoneBotException
 from nonebot.matcher import Matcher
 
-from ..chatmanager import chat_manager
+from ..chatmanager import SessionTemp, chat_manager
 from ..config import config_manager
 from ..event import BeforeChatEvent, ChatEvent
 from ..exception import CancelException
 from ..matcher import MatcherManager
 from ..utils.admin import (
     send_to_admin,
-    send_to_admin_as_error,
 )
 from ..utils.functions import (
     get_current_datetime_timestamp,
@@ -42,6 +42,9 @@ from ..utils.libchat import get_chat
 from ..utils.memory import MemoryModel, get_memory_data, write_memory_data
 from ..utils.tokenizer import hybrid_token_count
 
+_Group_Lock = defaultdict(asyncio.Lock)
+_Private_Lock = defaultdict(asyncio.Lock)
+command_prefix = get_driver().config.command_start or "/"
 
 async def chat(event: MessageEvent, matcher: Matcher, bot: Bot):
     """
@@ -249,7 +252,7 @@ async def chat(event: MessageEvent, matcher: Matcher, bot: Bot):
     async def manage_sessions(
         event: GroupMessageEvent | PrivateMessageEvent,
         data: MemoryModel,
-        session_clear_list: list,
+        session_clear_map: dict[str, SessionTemp],
     ):
         """
         管理会话上下文：
@@ -257,17 +260,16 @@ async def chat(event: MessageEvent, matcher: Matcher, bot: Bot):
         - 提供“继续”功能以恢复上下文。
         """
         if config_manager.config.session.session_control:
+            session_id = str(
+                event.group_id
+                if isinstance(event, GroupMessageEvent)
+                else event.user_id
+            )
             try:
-                for session in session_clear_list:
-                    if session["id"] == (
-                        event.group_id
-                        if isinstance(event, GroupMessageEvent)
-                        else event.user_id
-                    ):
-                        if not event.reply:
-                            session_clear_list.remove(session)
-                            return
-                        break
+                if session := session_clear_map.get(session_id):
+                    if "继续" not in event.message.extract_plain_text():
+                        del session_clear_map[session_id]
+                        return
 
                 # 检查会话超时
                 if (time.time() - data.timestamp) >= (
@@ -285,7 +287,6 @@ async def chat(event: MessageEvent, matcher: Matcher, bot: Bot):
                     ):
                         data.sessions.remove(data.sessions[0])
                     data.memory.messages = []
-                    data.timestamp = time.time()
                     await write_memory_data(event, data)
                     if not (
                         (time.time() - data.timestamp)
@@ -294,42 +295,28 @@ async def chat(event: MessageEvent, matcher: Matcher, bot: Bot):
                         )
                     ):
                         chated = await matcher.send(
-                            f'如果想和我继续用之前的上下文聊天，快回复我✨"继续"✨吧！\n（超过{config_manager.config.session.session_control_time}分钟没理我我就会被系统抱走存档哦！）'
+                            f'如果想和我继续用之前的上下文聊天，快at我回复✨"继续"✨吧！\n（超过{config_manager.config.session.session_control_time}分钟没理我我就会被系统抱走存档哦！）'
                         )
-                        session_clear_list.append(
-                            {
-                                "id": (
-                                    event.group_id
-                                    if isinstance(event, GroupMessageEvent)
-                                    else event.user_id
-                                ),
-                                "message_id": chated["message_id"],
-                                "timestamp": time.time(),
-                            }
+                        session_clear_map[session_id] = SessionTemp(
+                            message_id=chated["message_id"], timestamp=datetime.now()
                         )
+
                         raise CancelException()
                 else:
-                    for session in session_clear_list:
-                        if (
-                            session["id"]
-                            == (
-                                event.group_id
-                                if isinstance(event, GroupMessageEvent)
-                                else event.user_id
-                            )
-                            and "继续" in event.message.extract_plain_text()
-                        ):
-                            with contextlib.suppress(Exception):
-                                if time.time() - session["timestamp"] < 100:
-                                    await bot.delete_msg(
-                                        message_id=session["message_id"]
-                                    )
-                            session_clear_list.remove(session)
-                            data.memory.messages = data.sessions[-1]["messages"]
-                            data.sessions.pop()
-                            await matcher.send("让我们继续聊天吧～")
-                            await write_memory_data(event, data)
-                            raise CancelException()
+                    if (
+                        session := session_clear_map.get(session_id)
+                    ) and "继续" in event.message.extract_plain_text():
+                        with contextlib.suppress(Exception):
+                            if time.time() - session.timestamp.timestamp() < 100:
+                                await bot.delete_msg(message_id=session.message_id)
+
+                        del session_clear_map[session_id]
+
+                        data.memory.messages = data.sessions[-1]["messages"]
+                        data.sessions.pop()
+                        await matcher.send("让我们继续聊天吧～")
+                        await write_memory_data(event, data)
+                        raise CancelException()
 
             finally:
                 data.timestamp = time.time()
@@ -424,22 +411,10 @@ async def chat(event: MessageEvent, matcher: Matcher, bot: Bot):
                         f"提示词大小过大！为{hybrid_token_count(train['content'])}>{config_manager.config.session.session_max_tokens}！"
                     )
                     break
-            except Exception:
-                await send_to_admin_as_error("上下文限制清理出现异常！")
+            except Exception as e:
+                await send_to_admin(f"上下文限制清理出现异常！{e!s}")
+                logger.opt(exception=e, colors=True).exception(str(e))
 
-                exc_type, exc_value, exc_traceback = sys.exc_info()
-
-                await send_to_admin_as_error(
-                    f"Exception type: {exc_type.__name__}"
-                    if exc_type
-                    else "Exception type: None"
-                )
-                await send_to_admin_as_error(f"Exception message: {exc_value!s}")
-                import traceback
-
-                await send_to_admin_as_error(
-                    f"Detailed exception info:\n{''.join(traceback.format_exception(exc_type, exc_value, exc_traceback))}"
-                )
                 break
             full_string = ""
             for st in memory_l:
@@ -548,23 +523,28 @@ async def chat(event: MessageEvent, matcher: Matcher, bot: Bot):
     memory_length_limit = config_manager.config.llm_config.memory_lenth_limit
     Date = get_current_datetime_timestamp()
 
-    if event.message.extract_plain_text().strip().startswith("/"):
+    if any(
+        event.message.extract_plain_text().strip().startswith(prefix)
+        for prefix in command_prefix
+    ):
         matcher.skip()
 
-    if event.message.extract_plain_text().startswith("菜单"):
+    if event.message.extract_plain_text().startswith("聊天菜单"):
         await matcher.finish(chat_manager.menu_msg)
 
     try:
         if isinstance(event, GroupMessageEvent):
-            group_data = await get_memory_data(event)
-            await handle_group_message(
-                event, matcher, bot, group_data, memory_length_limit, Date
-            )  # type: ignore
+            async with _Group_Lock[event.group_id]:
+                group_data = await get_memory_data(event)
+                await handle_group_message(
+                    event, matcher, bot, group_data, memory_length_limit, Date
+                )  # type: ignore
         elif isinstance(event, PrivateMessageEvent):
-            private_data = await get_memory_data(event)
-            await handle_private_message(
-                event, matcher, bot, private_data, memory_length_limit, Date
-            )
+            async with _Private_Lock[event.user_id]:
+                private_data = await get_memory_data(event)
+                await handle_private_message(
+                    event, matcher, bot, private_data, memory_length_limit, Date
+                )
         else:
             matcher.skip()
     except NoneBotException as e:

--- a/nonebot_plugin_suggarchat/handlers/poke_event.py
+++ b/nonebot_plugin_suggarchat/handlers/poke_event.py
@@ -132,11 +132,7 @@ async def poke_event(event: PokeNotifyEvent, bot: Bot, matcher: Matcher):
     async def handle_poke_exception():
         """处理戳一戳事件中的异常"""
         exc_type, exc_value, exc_traceback = sys.exc_info()
-        logger.error(
-            f"Exception type: {exc_type.__name__}"
-            if exc_type
-            else "Exception type: None"
-        )
+        logger.exception("发生了异常")
         logger.error(f"Exception message: {exc_value!s}")
 
         # 将异常信息发送给管理员

--- a/nonebot_plugin_suggarchat/matcher.py
+++ b/nonebot_plugin_suggarchat/matcher.py
@@ -1,5 +1,4 @@
 import inspect
-import sys
 from collections.abc import Awaitable, Callable
 from copy import deepcopy
 from types import FrameType
@@ -213,21 +212,11 @@ class MatcherManager:
                     break
                 except NoneBotException:
                     raise
-                except Exception:
+                except Exception as e:
                     logger.error(
                         f"运行时发生了错误 '{handler.__name__}'({file_name}:{line_number}) "
                     )
-                    exc_type, exc_value, exc_traceback = sys.exc_info()
-                    logger.error(
-                        f"Exception type: {exc_type.__name__}"
-                        if exc_type
-                        else "Exception type: None"
-                    )
-                    logger.error(f"Exception message: {exc_value!s}")
-                    import traceback
-
-                    back = "".join(traceback.format_tb(exc_traceback))
-                    logger.error(back)
+                    logger.opt(exception=e, colors=True).exception(str(e))
                     continue
                 finally:
                     logger.info(f"处理器 {handler.__name__} 已结束")

--- a/nonebot_plugin_suggarchat/utils/libchat.py
+++ b/nonebot_plugin_suggarchat/utils/libchat.py
@@ -219,8 +219,8 @@ class ModelAdapter(ABC):
     async def call_api(self, messages: list[dict[str, Any]]) -> str:
         raise NotImplementedError
 
-    @abstractmethod
     @staticmethod
+    @abstractmethod
     def get_adapter_protocol() -> str:
         raise NotImplementedError
 

--- a/nonebot_plugin_suggarchat/utils/libchat.py
+++ b/nonebot_plugin_suggarchat/utils/libchat.py
@@ -206,9 +206,11 @@ async def openai_get_chat(
             raise RuntimeError("收到意外的响应类型")
     return response if response is not None else ""
 
-@dataclass(frozen=True)
 class ModelAdapter(ABC):
     """模型适配器抽象类"""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__()
 
     preset: ModelPreset
     config: Config

--- a/nonebot_plugin_suggarchat/utils/libchat.py
+++ b/nonebot_plugin_suggarchat/utils/libchat.py
@@ -1,7 +1,6 @@
 from abc import ABC, abstractmethod
 from collections.abc import Awaitable, Callable, Coroutine
 from copy import deepcopy
-from dataclasses import dataclass
 from typing import Any
 
 import nonebot
@@ -205,6 +204,7 @@ async def openai_get_chat(
         else:
             raise RuntimeError("收到意外的响应类型")
     return response if response is not None else ""
+
 
 class ModelAdapter(ABC):
     """模型适配器抽象类"""

--- a/nonebot_plugin_suggarchat/utils/libchat.py
+++ b/nonebot_plugin_suggarchat/utils/libchat.py
@@ -1,5 +1,7 @@
-from collections.abc import Callable, Coroutine
+from abc import ABC, abstractmethod
+from collections.abc import Awaitable, Callable, Coroutine
 from copy import deepcopy
+from dataclasses import dataclass
 from typing import Any
 
 import nonebot
@@ -16,7 +18,7 @@ from openai.types.chat.chat_completion_tool_choice_option_param import (
 )
 
 from ..chatmanager import chat_manager
-from ..config import Config, config_manager
+from ..config import Config, ModelPreset, config_manager
 from .functions import remove_think_tag
 
 
@@ -95,17 +97,21 @@ async def get_chat(
     err: Exception | None = None
     for pname in presets:
         preset = await config_manager.get_preset(pname, cache=False)
-        func = openai_get_chat
         # 根据预设选择API密钥和基础URL
         is_thought_chain_model = preset.thought_chain_model
-
+        func: (
+            Callable[[str, str, str, list, int, Config, Bot], Awaitable[str]] | None
+        ) = None
+        adapter: None | type[ModelAdapter] = None
         # 检查协议适配器
         if preset.protocol == "__main__":
             func = openai_get_chat
-        elif preset.protocol not in protocols_adapters:
-            raise ValueError(f"协议 {preset.protocol} 的适配器未找到!")
-        else:
+        elif preset.protocol in protocols_adapters:
             func = protocols_adapters[preset.protocol]
+        elif preset.protocol in adapter_class:
+            adapter = adapter_class[preset.protocol]
+        else:
+            raise ValueError(f"未定义的协议适配器：{preset.protocol}")
         # 记录日志
         logger.debug(f"开始获取 {preset.model} 的对话")
         logger.debug(f"预设：{config_manager.config.preset}")
@@ -116,15 +122,21 @@ async def get_chat(
 
         # 调用适配器获取聊天响应
         try:
-            response = await func(
-                preset.base_url,
-                preset.model,
-                preset.api_key,
-                messages,
-                max_tokens,
-                config_manager.config,
-                nb_bot,
-            )
+            if adapter is not None:
+                processer = adapter(preset, config_manager.config)
+                response = await processer.call_api(messages)
+            else:
+                assert func is not None, "适配器未找到"
+                response = await func(
+                    preset.base_url,
+                    preset.model,
+                    preset.api_key,
+                    messages,
+                    max_tokens,
+                    config_manager.config,
+                    nb_bot,
+                )
+
         except Exception as e:
             logger.warning(f"调用适配器失败{e}")
             err = e
@@ -194,8 +206,25 @@ async def openai_get_chat(
             raise RuntimeError("收到意外的响应类型")
     return response if response is not None else ""
 
+@dataclass(frozen=True)
+class ModelAdapter(ABC):
+    """模型适配器抽象类"""
+
+    preset: ModelPreset
+    config: Config
+
+    @abstractmethod
+    async def call_api(self, messages: list[dict[str, Any]]) -> str:
+        raise NotImplementedError
+
+    @abstractmethod
+    @staticmethod
+    def get_adapter_protocol() -> str:
+        raise NotImplementedError
+
 
 # 协议适配器映射
 protocols_adapters: dict[
     str, Callable[[str, str, str, list, int, Config, Bot], Coroutine[Any, Any, str]]
 ] = {"openai": openai_get_chat}
+adapter_class: dict[str, type[ModelAdapter]] = {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nonebot_plugin_suggarchat"
-version = "3.1.2.post2"
+version = "3.2.0.dev1"
 description = "SuggarChat chat framework"
 authors = [{ name = "LiteSuggarDEV", email = "windowserror@163.com" }]
 dependencies = [

--- a/tests/example/example_reg_config.py
+++ b/tests/example/example_reg_config.py
@@ -2,7 +2,7 @@ from nonebot import get_driver
 from nonebot.plugin import require
 
 require("nonebot_plugin_suggarchat")
-from nonebot_plugin_suggarchat.API import Config
+from nonebot_plugin_suggarchat.API import config_manager as Config
 
 
 @get_driver().on_startup

--- a/uv.lock
+++ b/uv.lock
@@ -674,7 +674,7 @@ wheels = [
 
 [[package]]
 name = "nonebot-plugin-suggarchat"
-version = "3.1.0"
+version = "3.2.0.dev1"
 source = { virtual = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Sourcery 总结

重构适配器系统，使其使用基于类的 ModelAdapter 注册表，与现有函数适配器并行；弃用旧的 Adapter API；并增强聊天处理器中的会话跟踪和并发控制。

增强功能：
- 从内存工具中移除全局文件锁，并简化 `get_memory_data`/`write_memory_data` 文件处理
- 添加每个对话的 asyncio 锁，并将会话跟踪切换到带有日期时间戳的 SessionTemp 映射
- 引入 ModelAdapter 抽象基类，包含 `Adapter.register_adapter_class` 和 `get_adapter_class(s)` 方法，并弃用旧的 `register_adapter`/`get_adapter` 方法
- 扩展 `get_chat`，使其根据协议分派到基于函数的适配器或新的基于类的适配器
- 统一 `matcher`、`libchat` 和 `poke_event` 中的异常日志记录，使用 `logger.opt.exception` 和 `logger.exception`
- 通过 `__all__` 在公共 API 中暴露 `Tokenizer`、`hybrid_token_count` 和 `tools_caller`

其他任务：
- 在 `pyproject.toml` 中将版本提升至 3.2.0.dev1

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the adapter system to use a class-based ModelAdapter registry alongside the existing function adapters, deprecate the old Adapter API, and enhance session tracking and concurrency control in chat handlers.

Enhancements:
- Remove global file lock from memory utils and streamline get_memory_data/write_memory_data file handling
- Add per-conversation asyncio locks and switch session tracking to a SessionTemp map with datetime timestamps
- Introduce ModelAdapter abstract base class with Adapter.register_adapter_class, get_adapter_class(s), and deprecate old register_adapter/get_adapter methods
- Extend get_chat to dispatch to either function-based adapters or new class-based adapters based on protocol
- Standardize exception logging across matcher, libchat, and poke_event using logger.opt.exception and logger.exception
- Expose Tokenizer, hybrid_token_count, and tools_caller in the public API via __all__

Chores:
- Bump version to 3.2.0.dev1 in pyproject.toml

</details>