### PR TITLE
更新Adapter注册逻辑

### DIFF
--- a/nonebot_plugin_suggarchat/config.py
+++ b/nonebot_plugin_suggarchat/config.py
@@ -24,7 +24,9 @@ DATA_DIR: Path = store.get_plugin_data_dir()
 nb_config = get_driver().config
 
 
-def replace_env_vars(data: dict | list | str) -> dict | list | str:
+def replace_env_vars(
+    data: dict[str, Any] | list[Any] | str,
+) -> dict[str, Any] | list[Any] | str:
     """递归替换环境变量占位符，但不修改原始数据"""
     data_copy = copy.deepcopy(data)  # 创建原始数据的深拷贝[4,5](@ref)
     if isinstance(data_copy, dict):
@@ -33,10 +35,10 @@ def replace_env_vars(data: dict | list | str) -> dict | list | str:
     elif isinstance(data_copy, list):
         for i in range(len(data_copy)):
             data_copy[i] = replace_env_vars(data_copy[i])
-    elif isinstance(data_copy, str):
+    else:
         pattern = r"\$\{(\w+)\}"
 
-        def replacer(match):
+        def replacer(match: re.Match[str]) -> str:
             var_name = match.group(1)
             return os.getenv(var_name, "")  # 若未设置环境变量，返回空字符串
 
@@ -45,7 +47,7 @@ def replace_env_vars(data: dict | list | str) -> dict | list | str:
 
 
 class ExtraModelPreset(BaseModel, extra="allow"):
-    def __getattr__(self, item) -> str:
+    def __getattr__(self, item: str) -> str:
         if item in self.__dict__:
             return self.__dict__[item]
         if self.__pydantic_extra__ and item in self.__pydantic_extra__:
@@ -176,7 +178,7 @@ class CookieModel(BaseModel):
 
 
 class ExtraConfig(BaseModel, extra="allow"):
-    def __getattr__(self, item) -> str:
+    def __getattr__(self, item: str) -> str:
         if item in self.__dict__:
             return self.__dict__[item]
         if self.__pydantic_extra__ and item in self.__pydantic_extra__:
@@ -327,8 +329,8 @@ class ConfigManager:
     private_prompts: Path = config_dir / "private_prompts"
     group_prompts: Path = config_dir / "group_prompts"
     custom_models_dir: Path = config_dir / "models"
-    _private_train: dict = field(default_factory=dict)
-    _group_train: dict = field(default_factory=dict)
+    _private_train: dict[str, Any] = field(default_factory=dict)
+    _group_train: dict[str, Any] = field(default_factory=dict)
     ins_config: Config = field(default_factory=Config)
     models: list[tuple[ModelPreset, str]] = field(default_factory=list)
     prompts: Prompts = field(default_factory=Prompts)

--- a/nonebot_plugin_suggarchat/preprocess.py
+++ b/nonebot_plugin_suggarchat/preprocess.py
@@ -13,9 +13,9 @@ __LOGO = r"""
 \_ \| U ( |_n( |_n| o ||   /
 |__/|___|\__/ \__/|_n_||_|\\"""
 
-
 @driver.on_bot_connect
 async def hook():
+    logger.debug("运行钩子...")
     await run_hooks()
 
 
@@ -31,5 +31,4 @@ async def onEnable():
         logger.warning("无法获取到版本！SuggarChat似乎并没有以pypi包方式运行。")
     logger.debug("加载配置文件...")
     await config_manager.load()
-    logger.debug("运行钩子...")
     logger.debug("成功启动！")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nonebot_plugin_suggarchat"
-version = "3.2.0.dev2"
+version = "3.2.0.dev3"
 description = "SuggarChat chat framework"
 authors = [{ name = "LiteSuggarDEV", email = "windowserror@163.com" }]
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -674,7 +674,7 @@ wheels = [
 
 [[package]]
 name = "nonebot-plugin-suggarchat"
-version = "3.2.0.dev1"
+version = "3.2.0.dev3"
 source = { virtual = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Sourcery 总结

将适配器注册集中到一个新的 BaseAdapter 类中，相应地迁移 OpenAIAdapter，通过在配置模块中添加显式类型注解来增强类型安全性，精简钩子调试日志，重新生成锁文件，并将版本提升至 3.2.0.dev3。

增强:
- 将适配器注册逻辑提取到一个新的 BaseAdapter 基类中，并将其从 ModelAdapter 中移除
- 重构 OpenAIAdapter 以继承 BaseAdapter 并自动注册
- 为 ExtraModelPreset/ExtraConfig 中的 replace_env_vars, __getattr__ 方法以及 ConfigManager 的字典属性添加显式类型注解
- 将调试日志 "运行钩子..." 重新定位到机器人连接钩子中，并移除 onEnable 中的重复项

构建:
- 将项目版本提升至 3.2.0.dev3

杂项:
- 重新生成 uv.lock 锁文件

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Centralize adapter registration in a new BaseAdapter class, migrate OpenAIAdapter accordingly, enhance type safety with explicit annotations in config modules, streamline hook debugging logs, regenerate lockfile, and bump version to 3.2.0.dev3.

Enhancements:
- Extract adapter registration logic into a new BaseAdapter base class and remove it from ModelAdapter
- Refactor OpenAIAdapter to subclass BaseAdapter and register automatically
- Add explicit type annotations to replace_env_vars, __getattr__ methods in ExtraModelPreset/ExtraConfig, and ConfigManager dict attributes
- Relocate the "运行钩子..." debug log to the bot connect hook and remove its duplicate in onEnable

Build:
- Bump project version to 3.2.0.dev3

Chores:
- Regenerate uv.lock lockfile

</details>