### PR TITLE
Fix adapter registration and simplify adapter hierarchy

### DIFF
--- a/nonebot_plugin_suggarchat/preprocess.py
+++ b/nonebot_plugin_suggarchat/preprocess.py
@@ -7,11 +7,10 @@ from .config import config_manager
 from .hook_manager import run_hooks
 
 driver = get_driver()
-__LOGO = r"""
- __  _ _  __   __   _   ___
-/ _|| | |/ _| / _| / \ | o \
-\_ \| U ( |_n( |_n| o ||   /
-|__/|___|\__/ \__/|_n_||_|\\"""
+__LOGO = """
+▄▖▖▖▄▖▄▖▄▖▄▖
+▚ ▌▌▌ ▌ ▌▌▙▘
+▄▌▙▌▙▌▙▌▛▌▌▌"""
 
 @driver.on_bot_connect
 async def hook():

--- a/nonebot_plugin_suggarchat/utils/libchat.py
+++ b/nonebot_plugin_suggarchat/utils/libchat.py
@@ -160,7 +160,8 @@ class ModelAdapter:
 
     def __init_subclass__(cls) -> None:
         super().__init_subclass__()
-        AdapterManager().register_adapter(cls)
+        if getattr(cls, "__abstract__", False):
+            AdapterManager().register_adapter(cls)
 
     @abstractmethod
     async def call_api(self, messages: Iterable[Any]) -> str:

--- a/nonebot_plugin_suggarchat/utils/libchat.py
+++ b/nonebot_plugin_suggarchat/utils/libchat.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from abc import abstractmethod
 from collections.abc import Iterable
 from copy import deepcopy
@@ -156,6 +158,10 @@ class ModelAdapter:
     config: Config
     __override__: bool = False  # 是否允许覆盖现有适配器
 
+    def __init_subclass__(cls) -> None:
+        super().__init_subclass__()
+        AdapterManager().register_adapter(cls)
+
     @abstractmethod
     async def call_api(self, messages: Iterable[Any]) -> str:
         raise NotImplementedError
@@ -197,7 +203,7 @@ class AdapterManager:
 
     def register_adapter(self, adapter: type[ModelAdapter]):
         """注册适配器"""
-        protocol = adapter.protocol
+        protocol = adapter.get_adapter_protocol()
         override = adapter.__override__ if hasattr(adapter, "__override__") else False
         if isinstance(protocol, str):
             if protocol in self._adapter_class:
@@ -221,15 +227,7 @@ class AdapterManager:
                 self._adapter_class[p] = adapter
 
 
-class BaseAdapter(ModelAdapter):
-    """基础适配器类，所有适配器都应继承自此类"""
-
-    def __init_subclass__(cls) -> None:
-        super().__init_subclass__()
-        AdapterManager().register_adapter(cls)
-
-
-class OpenAIAdapter(BaseAdapter):
+class OpenAIAdapter(ModelAdapter):
     """OpenAI协议适配器"""
 
     async def call_api(self, messages: Iterable[ChatCompletionMessageParam]) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nonebot_plugin_suggarchat"
-version = "3.2.0.dev4"
+version = "3.2.0.dev5"
 description = "SuggarChat chat framework"
 authors = [{ name = "LiteSuggarDEV", email = "windowserror@163.com" }]
 dependencies = [


### PR DESCRIPTION
## Sourcery 总结

修复适配器注册并简化适配器类层级，更新 ASCII 艺术 Logo，并提升插件版本

Bug 修复:
- 在继承时自动注册新的 ModelAdapter 子类
- 在注册适配器时使用 `get_adapter_protocol()` 而不是 `adapter.protocol`

增强功能:
- 移除 BaseAdapter 层，让 OpenAIAdapter 等适配器直接继承 ModelAdapter

构建:
- 将版本从 3.2.0.dev4 提升至 3.2.0.dev5

杂项:
- 更新插件的 ASCII 艺术 Logo

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix adapter registration and simplify adapter class hierarchy, update ASCII art logo, and bump plugin version

Bug Fixes:
- Automatically register new ModelAdapter subclasses on inheritance
- Use get_adapter_protocol() instead of adapter.protocol when registering adapters

Enhancements:
- Remove BaseAdapter layer and have adapters like OpenAIAdapter inherit directly from ModelAdapter

Build:
- Bump version from 3.2.0.dev4 to 3.2.0.dev5

Chores:
- Update the plugin's ASCII art logo

</details>