### PR TITLE
修复循环重载配置文件

### DIFF
--- a/nonebot_plugin_suggarchat/config.py
+++ b/nonebot_plugin_suggarchat/config.py
@@ -399,7 +399,7 @@ class ConfigManager:
                 for _, path in changes
             ):
                 logger.info("检测到提示词文件更改，正在重新加载提示词...")
-                await self.get_prompts(cache=False)
+                await self.get_prompts(cache=False, load_only=True)
                 await self.load_prompt()
                 logger.info("完成。")
             elif any(
@@ -462,7 +462,9 @@ class ConfigManager:
             await config_manager.save_config()
         return await self.get_preset("default", fix, cache)
 
-    async def get_prompts(self, cache: bool = False) -> Prompts:
+    async def get_prompts(
+        self, cache: bool = False, load_only: bool = False
+    ) -> Prompts:
         """获取提示词"""
         if cache and self.prompts:
             return self.prompts
@@ -484,8 +486,9 @@ class ConfigManager:
         if not self.prompts.group:
             self.prompts.group.append(Prompt("", "default"))
 
-        self.prompts.save_private(self.private_prompts)
-        self.prompts.save_group(self.group_prompts)
+        if not load_only:
+            self.prompts.save_private(self.private_prompts)
+            self.prompts.save_group(self.group_prompts)
 
         return self.prompts
 

--- a/nonebot_plugin_suggarchat/utils/lock.py
+++ b/nonebot_plugin_suggarchat/utils/lock.py
@@ -6,6 +6,7 @@ from functools import lru_cache
 def get_group_lock(_: int) -> asyncio.Lock:
     return asyncio.Lock()
 
+
 @lru_cache(maxsize=1024)
 def get_private_lock(_: int) -> asyncio.Lock:
     return asyncio.Lock()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nonebot_plugin_suggarchat"
-version = "3.2.1"
+version = "3.2.1.1"
 description = "SuggarChat chat framework"
 authors = [{ name = "LiteSuggarDEV", email = "windowserror@163.com" }]
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -689,7 +689,7 @@ wheels = [
 
 [[package]]
 name = "nonebot-plugin-suggarchat"
-version = "3.2.1"
+version = "3.2.1.1"
 source = { virtual = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Sourcery 总结

通过向 `get_prompts` 添加 `load_only` 标志来防止递归配置重新加载，并相应地更新版本和锁定文件

Bug 修复:
- 向 `get_prompts` 添加 `load_only` 参数，以在文件监视期间跳过保存提示，并避免无限重新加载循环

构建:
- 将包版本升级到 3.2.1.1

杂项:
- 在锁定工具中应用微小的格式调整，并更新依赖锁定文件

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent recursive configuration reload by adding a load_only flag to get_prompts, update version and lock file accordingly

Bug Fixes:
- Add load_only parameter to get_prompts to skip saving prompts during file watching and avoid infinite reload loop

Build:
- Bump package version to 3.2.1.1

Chores:
- Apply minor formatting adjustment in lock utility and update dependency lock file

</details>