### PR TITLE
修复e未绑定

### DIFF
--- a/nonebot_plugin_suggarchat/utils/libchat.py
+++ b/nonebot_plugin_suggarchat/utils/libchat.py
@@ -104,12 +104,13 @@ async def get_chat(
         # 调用适配器获取聊天响应
         try:
             for index in range(1, config_manager.config.llm_config.max_retries + 1):
-                e = None
+                ex = None
                 try:
                     processer = adapter(preset, config_manager.config)
                     response = await processer.call_api(messages)
                     break  # 成功获取响应，跳出重试循环
                 except Exception as e:
+                    ex = e
                     logger.warning(f"发生错误: {e}")
                     if index == config_manager.config.llm_config.max_retries:
                         logger.warning(
@@ -120,10 +121,10 @@ async def get_chat(
                     continue
                 finally:
                     if (
-                        e is not None
+                        ex is not None
                         and not config_manager.config.llm_config.auto_retry
                     ):
-                        raise e
+                        raise ex
         except Exception as e:
             logger.warning(f"调用适配器失败{e}")
             err = e

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nonebot_plugin_suggarchat"
-version = "3.2.1.1"
+version = "3.2.1.2"
 description = "SuggarChat chat framework"
 authors = [{ name = "LiteSuggarDEV", email = "windowserror@163.com" }]
 dependencies = [


### PR DESCRIPTION
## Sourcery 总结

修复 `get_chat` 重试逻辑中未绑定异常变量并提升版本

Bug 修复：
- 通过重命名变量修复 `get_chat` 重试 `finally` 块中未绑定异常变量

杂项：
- 将项目版本从 3.2.1.1 更新到 3.2.1.2

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix unbound exception variable in retry logic of get_chat and bump version

Bug Fixes:
- Fix unbound exception variable in get_chat retry finally block by renaming variable

Chores:
- Update project version from 3.2.1.1 to 3.2.1.2

</details>