### PR TITLE
修复循环导入

### DIFF
--- a/nonebot_plugin_suggarchat/event.py
+++ b/nonebot_plugin_suggarchat/event.py
@@ -8,8 +8,6 @@ from nonebot.adapters.onebot.v11 import (
 )
 from typing_extensions import override
 
-from .utils.memory import Message, ToolResult
-
 
 class EventTypeEnum(str, Enum):
     """
@@ -129,7 +127,7 @@ class SuggarEvent(BasicEvent):
         model_response: list[str],
         nbevent: Event,
         user_id: int,
-        send_message: list[Message | ToolResult],
+        send_message: list,
     ):
         """
         初始化SuggarEvent对象
@@ -148,7 +146,7 @@ class SuggarEvent(BasicEvent):
         # 初始化用户ID
         self._user_id: int = user_id
         # 初始化要发送的消息内容
-        self._send_message: list[Message | ToolResult] = send_message
+        self._send_message: list = send_message
 
     def __bool__(self):
         return True
@@ -267,7 +265,7 @@ class ChatEvent(SuggarEvent):
     def __init__(
         self,
         nbevent: MessageEvent,
-        send_message: list[Message | ToolResult],
+        send_message: list,
         model_response: list[str],
         user_id: int,
     ):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nonebot_plugin_suggarchat"
-version = "3.4.6"
+version = "3.4.6.1"
 description = "SuggarChat chat framework"
 authors = [{ name = "LiteSuggarDEV", email = "windowserror@163.com" }]
 dependencies = [


### PR DESCRIPTION
## Sourcery 总结

修复 `event.py` 中的循环导入，方法是移除内存导入并放宽 `send_message` 的类型提示，同时提升项目版本。

Bug 修复：
- 移除事件处理模块中 `Message` 和 `ToolResult` 的循环导入
- 调整 `send_message` 参数和属性类型以使用无类型列表，从而避免导入依赖

构建：
- 将版本从 3.4.6 提升至 3.4.6.1

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix circular import in event.py by removing memory imports and loosening send_message type hints, and bump the project version.

Bug Fixes:
- Remove circular import of Message and ToolResult in event handling module
- Adjust send_message parameter and attribute types to use untyped list to avoid import dependency

Build:
- Bump version from 3.4.6 to 3.4.6.1

</details>